### PR TITLE
call `Cache.Reset()` in finalizer

### DIFF
--- a/fastcache.go
+++ b/fastcache.go
@@ -5,6 +5,7 @@ package fastcache
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 
@@ -126,6 +127,7 @@ func New(maxBytes int) *Cache {
 	for i := range c.buckets[:] {
 		c.buckets[i].Init(maxBucketBytes)
 	}
+	runtime.SetFinalizer(&c, func(cache *Cache) { cache.Reset() })
 	return &c
 }
 


### PR DESCRIPTION
This PR sets `Cache` finalizer for each new cache to call `Cache.Reset` on GC to return used memory chunks to `freeChunks` pool. 

Note: the finalizer might not get called on GC, so the purpose of this PR is only to add some additional safety in case we forgot about reseting the cache in places where it's no longer needed