### PR TITLE
Merge go-wasi into master

### DIFF
--- a/malloc_heap.go
+++ b/malloc_heap.go
@@ -1,5 +1,5 @@
-//go:build appengine || windows || js
-// +build appengine windows js
+//go:build appengine || windows || wasm
+// +build appengine windows wasm
 
 package fastcache
 

--- a/malloc_mmap.go
+++ b/malloc_mmap.go
@@ -1,5 +1,5 @@
-//go:build !appengine && !windows && !js
-// +build !appengine,!windows,!js
+//go:build !appengine && !windows && !wasm
+// +build !appengine,!windows,!wasm
 
 package fastcache
 


### PR DESCRIPTION
This just switches the js build tag for wasm. It was already merged into the nitro submodule.